### PR TITLE
Update 02-regression.md

### DIFF
--- a/_episodes/02-regression.md
+++ b/_episodes/02-regression.md
@@ -51,7 +51,7 @@ def least_squares(data):
         x_sq_sum = x_sq_sum + (x**2)
         xy_sum = xy_sum + (x*y)
 
-    m = ((n * xy_sum) - (x_sum * y_sum))
+    m = ((n * xy_sum) - float(x_sum * y_sum))
     m = m / ((n * x_sq_sum) - (x_sum ** 2))
     c = (y_sum - m * x_sum) / n
 


### PR DESCRIPTION
Line #m = ((n * xy_sum) - (x_sum * y_sum)) This works fine in python 3 but incase someone is using python 2.7 still the float function will need to be called here since python 2.7 doesn't auto-convert int to float.