### PR TITLE
_config.yml: use Carpentries Incubator theme.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@
 # dc: Data Carpentry
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
-carpentry: "swc"
+carpentry: "incubator"
 
 # Overall title for pages.
 title: "Introduction to Machine Learning with Scikit Learn"
@@ -99,3 +99,6 @@ exclude:
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge
+
+# use remote theme
+remote_theme: carpentries/carpentries-theme


### PR DESCRIPTION
Hi,

If merged, this PR will:
  - switch 'carpentry' setting.
  - use remote Jekyll theme.

As mentioned in #1, I was having some difficulties building the lesson locally. This PR edits `_config.yml` to use the remote Carpentries Jekyll theme, and dispenses the need of static files (`_includes`, `assets`) to render the lesson (they can be removed in a future commit).

Best,
V