### PR TITLE
extra `]` removed to make code runnable

### DIFF
--- a/_episodes/02-regression.md
+++ b/_episodes/02-regression.md
@@ -148,7 +148,7 @@ def make_graph(x_data, y_data, linear_data):
     plt.show()
     
 x_data = [2,3,5,7,9]
-y_data = [4,5,7,10,15]]
+y_data = [4,5,7,10,15]
 
 m, c = least_squares([x_data, y_data])
 linear_data = make_linear(x_data, m, c)


### PR DESCRIPTION
`y_data = [4,5,7,10,15]]` is causing error because of the extra ending `square bracket` (`]`)at line `151` of the `_episodes/02-regression.md` file. Extra `]` has been removed.
